### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/scripts/extract-translations.js
+++ b/scripts/extract-translations.js
@@ -18,7 +18,7 @@ const parseCode = source => espree.parse(source, {
 
 function esc(s) {
     if (!s) return s;
-    return s.replace(/"/g, '\\"');
+    return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 const extractTextFromFunctions = (...method_names) => (parsed_code) => {


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/smartcharts-champion/security/code-scanning/1](https://github.com/deriv-com/smartcharts-champion/security/code-scanning/1)

To fix the issue, the `esc` function should be updated to escape backslashes (`\`) in addition to double quotes (`"`). This can be achieved by using a regular expression with the `g` (global) flag to replace all occurrences of backslashes with double backslashes (`\\`) and then replacing all double quotes with escaped double quotes (`\"`). The order of replacements is important: backslashes must be escaped first to avoid interfering with the escaping of double quotes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
