### PR TITLE
chore: add action file

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,0 +1,83 @@
+name: Checkout
+
+inputs:
+    fetch-depth:
+        default: 1
+        required: false
+        type: number
+    path:
+        required: false
+        type: string
+    repository:
+        default: ${{ github.repository }}
+        required: false
+        type: string
+    ref:
+        required: false
+        type: string
+    alternate_repository:
+        required: false
+        type: string
+    alternate_ref:
+        required: false
+        type: string
+    token:
+        default: ${{ github.token }}
+        required: false
+        type: string
+
+outputs:
+    ref_exists:
+        description: 'Specifies whether the ref exists or not'
+        value: ${{ steps.repo.outputs.ref-exists }}
+
+runs:
+    using: composite
+
+    steps:
+        - id: repo
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.token }}
+              ALTERNATE_REF: ${{ inputs.alternate_ref }}
+              REPOSITORY: ${{ inputs.repository }}
+              REF: ${{ inputs.ref }}
+          run: |
+              if git ls-remote --heads --quiet --exit-code https://$GH_TOKEN@github.com/$REPOSITORY.git $REF
+              then
+                echo "::notice::Checkout: $REPOSITORY using $REF"
+                echo "ref-exists=true" >> $GITHUB_OUTPUT
+              else
+                echo "::notice::Checkout: $REPOSITORY does not have ref  $REF (fallback to $ALTERNATE_REF)"
+                echo "ref-exists=false" >> $GITHUB_OUTPUT
+              fi
+
+        - if: steps.repo.outputs.ref-exists == 'true'
+          uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+          env:
+              REPO_PATH: ${{ inputs.path }}
+              GH_TOKEN: ${{ inputs.token }}
+              REPOSITORY: ${{ inputs.repository }}
+              FETCH_DEPTH: ${{ inputs.fetch-depth }}
+              REF: ${{ inputs.ref }}
+          with:
+              fetch-depth: ${{ env.FETCH_DEPTH }}
+              path: ${{ env.REPO_PATH }}
+              repository: ${{ env.REPOSITORY }}
+              ref: ${{ env.REF }}
+              token: ${{ env.GH_TOKEN }}
+
+        - if: steps.repo.outputs.ref-exists == 'false'
+          uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+          env:
+              REPO_PATH: ${{ inputs.path }}
+              GH_TOKEN: ${{ inputs.token }}
+              ALTERNATE_REF: ${{ inputs.alternate_ref }}
+              ALTERNATE_REPOSITORY: ${{ inputs.alternate_repository }}
+              FETCH_DEPTH: ${{ inputs.fetch-depth }}
+          with:
+              fetch-depth: ${{ env.FETCH_DEPTH }}
+              path: ${{ env.REPO_PATH }}
+              repository: ${{ env.ALTERNATE_REPOSITORY }}
+              ref: ${{ env.ALTERNATE_REF }}
+              token: ${{ env.GH_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new composite GitHub Action in `.github/actions/checkout/action.yml` to enhance repository checkout workflows. The action adds logic to check if a specific git ref exists in a repository and conditionally falls back to an alternate repository and ref if it does not. It also exposes an output indicating whether the desired ref was found.

Repository checkout improvements:

* Added a composite action that checks for the existence of a specified git ref in a repository before performing the checkout, allowing for conditional fallback to an alternate repository and ref.
* Defined inputs for fetch depth, path, repository, ref, alternate repository, alternate ref, and token to make the action configurable for different use cases.
* Exposed an output `ref_exists` to indicate whether the specified ref was found, enabling downstream workflow steps to react accordingly.