### PR TITLE
fix: externalize react/jsx-runtime and react/jsx-dev-runtime in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -209,6 +209,16 @@ const config = {
             commonjs: 'react',
             commonjs2: 'react',
         },
+        'react/jsx-runtime': {
+            commonjs: 'react/jsx-runtime',
+            commonjs2: 'react/jsx-runtime',
+            root: ['React'],
+        },
+        'react/jsx-dev-runtime': {
+            commonjs: 'react/jsx-dev-runtime',
+            commonjs2: 'react/jsx-dev-runtime',
+            root: ['React'],
+        },
         'react-dom': {
             commonjs: 'react-dom',
             commonjs2: 'react-dom',


### PR DESCRIPTION
## Problem

When consuming `@deriv-com/smartcharts-champion` in a Next.js app running
Turbopack, the bundle crashes immediately on load with:

> Cannot read properties of undefined (reading 'ReactCurrentOwner')

### Root cause

`.babelrc` uses `@babel/preset-react` with `runtime: "automatic"`. Babel
compiles JSX to import from `react/jsx-dev-runtime` (dev) and
`react/jsx-runtime` (prod) instead of calling `React.createElement`.
Neither sub-path was listed in webpack `externals`, so both modules were
**bundled into `smartcharts.js`**.

The bundled copy of `react-jsx-dev-runtime` does this at module evaluation
time (top-level, not inside a function):

```js
var i = r(809)  // module 809 = the react external
var o = i.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner
```

With **webpack** (the consuming bundler), `require("react")` returns the
bare CJS object — works fine.

With **Turbopack**, `require("react")` goes through its ESM interop layer
and returns `{ default: React, useState, … }` instead of bare React.
`i.__SECRET_INTERNALS` is `undefined` → crash at module load, before any
user code runs.

## Fix

Add `react/jsx-runtime` and `react/jsx-dev-runtime` to the webpack
`externals` block alongside `react` and `react-dom`:

```js
'react/jsx-runtime': {
    commonjs: 'react/jsx-runtime',
    commonjs2: 'react/jsx-runtime',
    root: ['React'],
},
'react/jsx-dev-runtime': {
    commonjs: 'react/jsx-dev-runtime',
    commonjs2: 'react/jsx-dev-runtime',
    root: ['React'],
},
```

Both runtimes are now **required from the consuming app's React
installation** rather than bundled. This is the standard pattern for
libraries using the automatic JSX transform — the consuming bundler handles
CJS/ESM interop at the entry level, where it works correctly regardless of
whether webpack or Turbopack is used.