### PR TITLE
chore: improve take profit , stop loss and stop out lines design

### DIFF
--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -211,4 +211,58 @@
     /* stylelint-enable plugin/no-unsupported-browser-features */
 }
 
+/* Inline-label variant (used by host apps that pass useInlineLabel) */
+
+.chart-line--inline-label {
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: 100%;
+    height: 0;
+    left: 0;
+
+    .price-line-inline__line {
+        flex: 1 1 auto;
+        height: 0;
+        border-top-width: 1px;
+        margin: 0;
+        min-width: 0;
+    }
+    .price-line-inline__label-row {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        padding-right: 4px;
+        padding-left: 4px;
+        font-size: 12px;
+        line-height: 20px;
+        font-weight: normal;
+        white-space: nowrap;
+    }
+    .price-line-inline__chevron {
+        flex-shrink: 0;
+    }
+    .price-line-inline__title {
+        padding: 0 4px;
+    }
+    .price-line-inline__pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2px 8px;
+        border: 1px solid;
+        border-radius: 4px;
+        font-size: 12px;
+        line-height: 20px;
+        font-feature-settings: 'lnum' 1, 'tnum' 1;
+        background-color: $COLOR_WHITE;
+    }
+}
+
+.smartcharts-dark .chart-line--inline-label .price-line-inline__pill {
+    background-color: $color-black-1;
+}
+
 /*! rtl:end:ignore */

--- a/src/components/Barrier.tsx
+++ b/src/components/Barrier.tsx
@@ -30,6 +30,7 @@ const Barrier = ({ store, ...props }: TBarrierBaseProps) => {
         lineStyle,
         opacityOnOverlap,
         shadeColor = '#008832',
+        useInlineLabel,
     } = store;
 
     const barrierRef = React.useRef<HTMLDivElement>(null);
@@ -61,6 +62,7 @@ const Barrier = ({ store, ...props }: TBarrierBaseProps) => {
                 hideOffscreenLine={hideOffscreenLine}
                 hideBarrierLine={hideBarrierLine}
                 opacityOnOverlap={opacityOnOverlap}
+                useInlineLabel={useInlineLabel}
                 {...props}
             />
             {!isSingleBarrier && (

--- a/src/components/Barrier.tsx
+++ b/src/components/Barrier.tsx
@@ -77,6 +77,7 @@ const Barrier = ({ store, ...props }: TBarrierBaseProps) => {
                         hideOffscreenLine={hideOffscreenLine}
                         hideBarrierLine={hideBarrierLine}
                         opacityOnOverlap={opacityOnOverlap}
+                        useInlineLabel={useInlineLabel}
                         {...props}
                     />
                     <Shade store={aboveShadeStore} />

--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite';
 import classNames from 'classnames';
 import PriceLineStore from 'src/store/PriceLineStore';
 import PriceLineArrow from './PriceLineArrow';
+import PriceLineInline from './PriceLineInline';
 import PriceLineTitle from './PriceLineTitle';
 import HamburgerDragIcon from './HamburgerDragIcon';
 
@@ -17,6 +18,7 @@ type TPriceLineProps = {
     color?: string;
     opacityOnOverlap: number;
     title?: string;
+    useInlineLabel?: boolean;
 };
 
 const PriceLine = ({
@@ -30,7 +32,23 @@ const PriceLine = ({
     hideBarrierLine,
     store,
     title,
+    useInlineLabel,
 }: TPriceLineProps) => {
+    if (useInlineLabel) {
+        return (
+            <PriceLineInline
+                store={store}
+                lineStyle={lineStyle}
+                color={color}
+                hideOffscreenBarrier={hideOffscreenBarrier}
+                hideOffscreenLine={hideOffscreenLine}
+                hideBarrierLine={hideBarrierLine}
+                opacityOnOverlap={opacityOnOverlap}
+                title={title}
+            />
+        );
+    }
+
     const {
         className,
         draggable,

--- a/src/components/PriceLineInline.tsx
+++ b/src/components/PriceLineInline.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+import classNames from 'classnames';
+import PriceLineStore from 'src/store/PriceLineStore';
+import { DIRECTIONS } from '../utils';
+
+type TPriceLineInlineProps = {
+    store: PriceLineStore;
+    lineStyle?: React.CSSProperties['borderStyle'];
+    hideOffscreenBarrier?: boolean;
+    hideOffscreenLine?: boolean;
+    hideBarrierLine?: boolean;
+    color?: string;
+    opacityOnOverlap: number;
+    title?: string;
+};
+
+const ChevronIcon = ({ direction, color }: { direction: keyof typeof DIRECTIONS; color?: string }) => (
+    <svg
+        className='price-line-inline__chevron'
+        width='10'
+        height='10'
+        viewBox='0 0 10 10'
+        fill='none'
+        xmlns='http://www.w3.org/2000/svg'
+        style={{ transform: direction === DIRECTIONS.DOWN ? 'rotate(180deg)' : undefined }}
+    >
+        <path
+            d='M2 4.5L5 1.5L8 4.5M2 8.5L5 5.5L8 8.5'
+            stroke={color}
+            strokeWidth='1.2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+        />
+    </svg>
+);
+
+const PriceLineInline = ({
+    lineStyle,
+    color,
+    hideOffscreenBarrier,
+    opacityOnOverlap,
+    hideOffscreenLine,
+    hideBarrierLine,
+    store,
+    title,
+}: TPriceLineInlineProps) => {
+    const { className, init, isOverlapping, offScreen, offScreenDirection, priceDisplay, setDragLine, visible } = store;
+    const showBarrier = React.useMemo(() => !(hideOffscreenBarrier && offScreen), [hideOffscreenBarrier, offScreen]);
+    const showLine = React.useMemo(
+        () => !hideBarrierLine && (!hideOffscreenLine || !offScreen) && !isOverlapping,
+        [hideBarrierLine, hideOffscreenLine, offScreen, isOverlapping]
+    );
+    const opacity = React.useMemo(() => (isOverlapping ? opacityOnOverlap : ''), [isOverlapping, opacityOnOverlap]);
+
+    React.useEffect(() => {
+        init();
+    }, [init]);
+
+    if (!showBarrier) return null;
+
+    return (
+        <div className='barrier-area' ref={setDragLine} hidden={!visible}>
+            <div
+                className={classNames('chart-line', 'chart-line--inline-label', 'horizontal', className || '')}
+                style={{ color, opacity }}
+            >
+                {showLine && (
+                    <div
+                        className='price-line-inline__line'
+                        style={{
+                            borderTopColor: color,
+                            borderTopStyle: lineStyle as React.CSSProperties['borderTopStyle'],
+                        }}
+                    />
+                )}
+                <div className='price-line-inline__label-row' style={{ color }}>
+                    {offScreen && offScreenDirection && <ChevronIcon direction={offScreenDirection} color={color} />}
+                    {title && <span className='price-line-inline__title'>{title}</span>}
+                    <span
+                        className='price-line-inline__pill'
+                        style={{ borderColor: color, color }}
+                    >
+                        {priceDisplay}
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default observer(PriceLineInline);

--- a/src/store/BarrierStore.ts
+++ b/src/store/BarrierStore.ts
@@ -54,6 +54,7 @@ export default class BarrierStore {
     hideOffscreenLine = false;
     hideOffscreenBarrier = false;
     isSingleBarrier = false;
+    useInlineLabel = false;
 
     _shadeState = '';
 
@@ -81,6 +82,7 @@ export default class BarrierStore {
             isSingleBarrier: observable,
             isTopShadeVisible: observable,
             lineStyle: observable,
+            useInlineLabel: observable,
             pip: computed,
             shadeColor: observable,
             updateProps: action.bound,
@@ -144,6 +146,7 @@ export default class BarrierStore {
         showOffscreenArrows,
         isSingleBarrier,
         opacityOnOverlap,
+        useInlineLabel,
     }: TBarrierUpdateProps): void {
         this.initializePromise.then(
             action(() => {
@@ -194,6 +197,7 @@ export default class BarrierStore {
                 this.hideOffscreenLine = !!hideOffscreenLine;
                 this.hideOffscreenBarrier = !!hideOffscreenBarrier;
                 this.isSingleBarrier = !!isSingleBarrier;
+                this.useInlineLabel = !!useInlineLabel;
             })
         );
         if (opacityOnOverlap) {

--- a/src/types/props.types.ts
+++ b/src/types/props.types.ts
@@ -228,6 +228,7 @@ export type TBarrierUpdateProps = {
     showOffscreenArrows?: boolean;
     isSingleBarrier?: boolean;
     opacityOnOverlap?: number;
+    useInlineLabel?: boolean;
     key: string;
 };
 


### PR DESCRIPTION
# Inline-label barrier variant for TP / SL / Stop-Out markers

## Summary

Adds an opt-in `useInlineLabel` mode to the barrier renderer so host apps can display TP / SL / Stop-Out lines using the new design: a colored line that stops before an inline label row containing an optional off-screen chevron, the title, and a price pill — everything sharing the marker color and the same vertical center.

The default barrier rendering path is unchanged; non-opted-in consumers see no visual difference.

## What changed

- **New prop**: `useInlineLabel?: boolean` on `TBarrierUpdateProps` (`src/types/props.types.ts`), threaded through `BarrierStore.updateProps` and `Barrier.tsx`.
- **New component**: `src/components/PriceLineInline.tsx` renders the inline-label layout. Uses an inline SVG chevron driven by `PriceLineStore.offScreenDirection` (up when the barrier scrolls above the viewport, down when below). No new asset files.
- **`PriceLine.tsx`**: early-returns to `PriceLineInline` when `useInlineLabel` is true; original render path untouched.
- **Styles** (`sass/components/_barrier.scss`):
  - Flex layout (`align-items: center`) so the horizontal line and the label row share the same vertical baseline.
  - Line is `flex: 1 1 auto`; label row is `flex: 0 0 auto` — the line grows until it meets the label and stops there.
  - Pill: 1px colored border, 4px radius, 2×8 padding, tabular numbers (`'lnum' 1, 'tnum' 1`), 12 / 20 caption typography.
  - Pill background is `$COLOR_WHITE` in light mode and `$color-black-1` (`#181c25`) in dark mode to match the chart surface.

## Why

The previous barrier render put the title left of the price pill with a hardcoded green/orange off-screen arrow stacked above/below, and the line ran the full width underneath the pill. The new design (per Figma) needs:

- a single-color marker (line + label + pill border + pill text + off-screen chevron all share `color`),
- the line to stop before the label rather than running under it,
- a themed surface for the pill so it reads against the chart background.

Rather than mutating the default render path and risking regressions for digits, vanilla, touch/no-touch and other consumers that rely on the existing visuals, this PR introduces an opt-in variant. Only consumers that explicitly pass `useInlineLabel: true` get the new look.

## How to use (host side)

```ts
barrier.useInlineLabel = true;
barrier.color = '#008832';            // TP green / SL red / Stop-out orange
barrier.lineStyle = 'solid';
barrier.hideOffscreenLine = true;     // recommended: hides the line when off-screen
```

The host's existing `color`, `title`, `lineStyle`, `hideOffscreenLine`, and price value props all flow through unchanged.