### PR TITLE
fix: drawing-tools lifecycle (load timing, symbol switch sync, contract-details chart isolation)

### DIFF
--- a/chart_app/lib/deriv_chart_wrapper.dart
+++ b/chart_app/lib/deriv_chart_wrapper.dart
@@ -249,6 +249,15 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                             : InteractiveLayerDesktopBehaviour());
 
                     return DerivChart(
+                      // Force a full remount when toggling between live (trade)
+                      // and data-fit (contract-details replay) modes. Without
+                      // a key flip, DerivChart and its `InteractiveLayer` child
+                      // would just rebuild with new props, but `InteractiveLayer`
+                      // has no `didUpdateWidget` for `drawingToolsRepo`, so its
+                      // listener stays bound to the previous repo and its
+                      // `_interactableDrawings` State map keeps the previous
+                      // chart's drawings. Re-keying discards that State.
+                      key: ValueKey<bool>(configModel.startWithDataFitMode),
                       activeSymbol: configModel.symbol,
                       mainSeries: mainSeries,
                       annotations: feedModel.ticks.isNotEmpty
@@ -308,7 +317,14 @@ class DerivChartWrapperState extends State<DerivChartWrapper> {
                         markerGroupList: configModel.markerGroupList,
                         markerGroupIconPainter: getMarkerGroupPainter(app),
                       ),
-                      drawingToolsRepo: drawingToolModel.drawingToolsRepo,
+                      // Replay charts get an always-empty drawing-tools repo
+                      // so the `InteractiveLayer` has nothing to render. Per-
+                      // symbol persistence in SharedPreferences is untouched —
+                      // when the user returns to the trade chart, the live
+                      // repo reloads via `loadAndNotifyDrawings`.
+                      drawingToolsRepo: configModel.startWithDataFitMode
+                          ? drawingToolModel.emptyDrawingToolsRepo
+                          : drawingToolModel.drawingToolsRepo,
                       drawingTools: drawingToolModel.drawingTools,
                       indicatorsRepo: indicatorsModel.indicatorsRepo,
                       dataFitEnabled: configModel.startWithDataFitMode,

--- a/chart_app/lib/src/chart_app.dart
+++ b/chart_app/lib/src/chart_app.dart
@@ -37,6 +37,12 @@ class ChartApp {
 
   bool _prevShowChart = false;
 
+  /// Monotonic counter bumped on every [newChart]. A `newChart` coroutine
+  /// captures its generation before awaiting [chartReady]; if a later
+  /// `newChart` has since superseded it, the stale coroutine bails out instead
+  /// of loading drawings for an outdated payload/symbol.
+  int _chartGeneration = 0;
+
   /// height of xAxis
   double xAxisHeight = 24;
 
@@ -86,13 +92,21 @@ class ChartApp {
 
   /// Initialize new chart
   Future<void> newChart(JSNewChart payload) async {
+    final int generation = ++_chartGeneration;
+
     // Re-arm the readiness gate for the new chart instance. The previous
     // completer may already have fired for an earlier chart; we want a fresh
-    // one that completes when THIS chart's first frame is painted. If a prior
-    // newChart is still pending (rapid symbol switch), it shares this same
-    // completer — both calls resolve when the chart mounts and both run
-    // loadAndNotifyDrawings against the latest symbol, which is redundant but
-    // correct (the latest call's `drawingToolModel.symbol` wins).
+    // one that completes when THIS chart's first frame is painted.
+    //
+    // We deliberately only swap in a fresh completer when the previous one has
+    // already completed. If a prior `newChart` is still pending (rapid symbol
+    // switch, or a feed-load that never arrived because JS threw between its
+    // paired `app.newChart` / `feed.onTickHistory` calls), it is suspended on
+    // THIS completer instance — replacing it would orphan that coroutine on a
+    // future that can never complete, hanging it forever. By sharing the
+    // completer, the pending call resolves alongside this one when the chart
+    // mounts; the `generation` guard below then ensures only the latest
+    // `newChart` actually loads drawings.
     if (_chartReadyCompleter.isCompleted) {
       _chartReadyCompleter = Completer<void>();
     }
@@ -114,6 +128,14 @@ class ChartApp {
     // Defer drawing-tool load until the chart's render surface and feed are
     // live.
     await chartReady;
+
+    // A newer newChart() superseded this one while we were awaiting readiness
+    // (e.g. the user switched symbol again, or navigated to the contract-details
+    // chart which mounts with a different payload). Bail so we don't load this
+    // payload's drawings on top of — or against the symbol of — the newer chart.
+    if (generation != _chartGeneration) {
+      return;
+    }
 
     // Contract-details charts mount with `startWithDataFitMode=true`
     // and are wired to the empty drawing-tools repo in `deriv_chart_wrapper`,

--- a/chart_app/lib/src/chart_app.dart
+++ b/chart_app/lib/src/chart_app.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:chart_app/src/interop/js_interop.dart';
@@ -48,11 +49,23 @@ class ChartApp {
   /// Whether chart is mounted or not.
   bool isMounted = false;
 
+  /// Completes once the chart is mounted (feed loaded + first frame painted).
+  /// Awaiting [chartReady] is the proper signal for any operation that needs
+  /// the price-axis coordinate system / render surface to exist — e.g. loading
+  /// saved drawing tools. Reset on every [newChart] so symbol switches re-arm.
+  Completer<void> _chartReadyCompleter = Completer<void>();
+
+  /// Future that resolves when the chart is ready to accept render-dependent ops.
+  Future<void> get chartReady => _chartReadyCompleter.future;
+
   void _processChartVisibilityChange(bool showChart) {
     if (showChart) {
       /// To prevent controller functions being called before mount.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         isMounted = true;
+        if (!_chartReadyCompleter.isCompleted) {
+          _chartReadyCompleter.complete();
+        }
       });
     } else {
       isMounted = false;
@@ -72,10 +85,42 @@ class ChartApp {
   }
 
   /// Initialize new chart
-  void newChart(JSNewChart payload) {
+  Future<void> newChart(JSNewChart payload) async {
+    // Re-arm the readiness gate for the new chart instance. The previous
+    // completer may already have fired for an earlier chart; we want a fresh
+    // one that completes when THIS chart's first frame is painted. If a prior
+    // newChart is still pending (rapid symbol switch), it shares this same
+    // completer — both calls resolve when the chart mounts and both run
+    // loadAndNotifyDrawings against the latest symbol, which is redundant but
+    // correct (the latest call's `drawingToolModel.symbol` wins).
+    if (_chartReadyCompleter.isCompleted) {
+      _chartReadyCompleter = Completer<void>();
+    }
+
+    // Force the next visibility-change detection in [getChartVisibilitity] to
+    // fire. On symbol switch the JS side calls `app.newChart` and
+    // `feed.onTickHistory` back-to-back, so `feedLoadedNotifier` flips
+    // false → true within the same microtask batch — no frame ever renders
+    // with showChart=false. Without resetting this, the next frame would see
+    // showChart unchanged (true → true), skip [_processChartVisibilityChange]
+    // entirely, and [_chartReadyCompleter] would hang forever — leaving the
+    // previous symbol's drawings stuck in the InteractiveLayer's local state.
+    _prevShowChart = false;
+
     configModel.newChart(payload);
     drawingToolModel.newChart(payload);
     feedModel.newChart();
+
+    // Defer drawing-tool load until the chart's render surface and feed are
+    // live.
+    await chartReady;
+
+    // Contract-details charts mount with `startWithDataFitMode=true`
+    // and are wired to the empty drawing-tools repo in `deriv_chart_wrapper`,
+    // so they must never have anything render.
+    if (!payload.startWithDataFitMode) {
+      await drawingToolModel.loadAndNotifyDrawings();
+    }
   }
 
   /// Calculates the width of yAxis and sets the height of xAxis

--- a/chart_app/lib/src/interop/dart_interop.dart
+++ b/chart_app/lib/src/interop/dart_interop.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:js_interop';
 import 'package:web/web.dart' as web;
 import 'dart:js_interop_unsafe';
@@ -23,7 +24,10 @@ class AppWrapper {
   double getXAxisHeight() => _app.xAxisHeight;
   double getYAxisWidth() => _app.yAxisWidth;
   double getCurrentTickWidth() => _app.currentTickWidth;
-  void newChart(JSNewChart payload) => _app.newChart(payload);
+  // ChartApp.newChart is async (it awaits chart-ready before loading
+  // saved drawings), but the JS bridge stays fire-and-forget — JS does not
+  // await it. unawaited() makes that explicit for the analyzer.
+  void newChart(JSNewChart payload) => unawaited(_app.newChart(payload));
   List<dynamic>? getTooltipContent(int epoch, int pipSize) =>
       _app.getTooltipContent(epoch, pipSize);
   int? getIndicatorHoverIndex(double x, double y, Function getClosestEpoch,
@@ -91,12 +95,11 @@ class ChartConfigWrapper {
   void updateChartStyle(String style) => _model.updateChartStyle(style);
   void setRemainingTime(String time) => _model.setRemainingTime(time);
   void updateContracts(JSAny contracts) {
-    final List<JSContractsUpdate> contractsList =
-        (contracts as JSArray<JSAny>)
-            .toDart
-            .whereType<JSAny>()
-            .map((JSAny c) => c as JSContractsUpdate)
-            .toList();
+    final List<JSContractsUpdate> contractsList = (contracts as JSArray<JSAny>)
+        .toDart
+        .whereType<JSAny>()
+        .map((JSAny c) => c as JSContractsUpdate)
+        .toList();
     _model.updateContracts(contractsList);
   }
 
@@ -106,9 +109,11 @@ class ChartConfigWrapper {
   void updateLeftMargin(double? margin) {
     if (margin != null) _model.updateLeftMargin(margin);
   }
+
   void updateRightPadding(int? padding) {
     if (padding != null) _model.updateRightPadding(padding);
   }
+
   void toggleTimeIntervalVisibility(bool visible) =>
       _model.toggleTimeIntervalVisibility(visible);
   void setSymbolClosed(bool closed) => _model.setSymbolClosed(closed);

--- a/chart_app/lib/src/models/drawing_tool.dart
+++ b/chart_app/lib/src/models/drawing_tool.dart
@@ -67,6 +67,8 @@ class DrawingToolModel {
   /// awaiting `chartReady` and then invoking [loadAndNotifyDrawings].
   void newChart(JSNewChart payload) {
     symbol = payload.symbol ?? '';
+    // Deselect any drawing so the next mount starts in InteractiveNormalState.
+    interactiveLayerBehaviour.resetToNormalState();
   }
 
   /// Loads drawings for the current [symbol] from SharedPreferences and

--- a/chart_app/lib/src/models/drawing_tool.dart
+++ b/chart_app/lib/src/models/drawing_tool.dart
@@ -44,41 +44,46 @@ class DrawingToolModel {
   /// Drawing tools repo
   late AddOnsRepository<DrawingToolConfig> drawingToolsRepo;
 
+  /// An always-empty drawing-tools repo handed to read-only chart instances
+  /// (e.g. the contract-details replay chart). Passing this instead of
+  /// [drawingToolsRepo] ensures the `InteractiveLayer` has nothing to render
+  /// — `items` is empty and there is no UI path that adds to it. We never
+  /// call `loadFromPrefs` on this repo, so it stays empty for the lifetime
+  /// of the app and never overwrites SharedPreferences. The trade chart
+  /// continues using the live [drawingToolsRepo] unchanged.
+  final AddOnsRepository<DrawingToolConfig> emptyDrawingToolsRepo =
+      AddOnsRepository<DrawingToolConfig>(
+    createAddOn: (Map<String, dynamic> map) => DrawingToolConfig.fromJson(map),
+    sharedPrefKey: '__replay_no_drawings__',
+  );
+
   /// DrawingTools
   late DrawingTools drawingTools;
 
   InteractiveLayerController get interactiveLayerController =>
       interactiveLayerBehaviour.controller;
 
-  /// Initialize new chart
+  /// Initialize new chart. Caller (ChartApp.newChart) is responsible for
+  /// awaiting `chartReady` and then invoking [loadAndNotifyDrawings].
   void newChart(JSNewChart payload) {
     symbol = payload.symbol ?? '';
-
-    // Wait for the chart to be fully initialized before loading drawing tools
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // TODO(Jim): Find a better way to ensure the chart is ready
-      // Wait for chart initialization to complete
-      await Future.delayed(const Duration(milliseconds: 5000));
-      await _loadSavedDrawingTools();
-    });
   }
 
-  Future<void> _loadSavedDrawingTools() async {
+  /// Loads drawings for the current [symbol] from SharedPreferences and
+  /// notifies the JS side. Must be invoked AFTER the chart is mounted
+  /// (await `ChartApp.chartReady` first); otherwise drawings would attempt to
+  /// resolve their epoch/quote coordinates before the price axis exists.
+  ///
+  /// The JS-side notification fires unconditionally — even with an empty list
+  /// — because `DrawToolsStore.onLoad` is the only path that resets the JS
+  /// `activeToolsGroup` cache. Skipping the call on symbols with no saved
+  /// drawings would leave the previous symbol's tools listed in the JS UI
+  /// panel/badge while the Flutter chart underneath is correctly empty.
+  Future<void> loadAndNotifyDrawings() async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     drawingToolsRepo.loadFromPrefs(prefs, symbol);
 
-    // Use WidgetsBinding to ensure the UI is ready and then notify JavaScript
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // TODO(Jim): Find a better way to ensure the chart is ready
-      // Add a delay to ensure the chart is fully initialized and ready to render
-      await Future.delayed(const Duration(milliseconds: 1000));
-
-      final List<String> drawingToolsJson = getDrawingToolsRepoItems();
-      if (drawingToolsJson.isNotEmpty) {
-        // Notify JavaScript side that drawing tools have been loaded
-        JsInterop.drawingTool?.onLoad?.call(drawingToolsJson);
-      }
-    });
+    JsInterop.drawingTool?.onLoad?.call(getDrawingToolsRepoItems());
   }
 
   /// To select a drawing

--- a/src/store/ChartState.ts
+++ b/src/store/ChartState.ts
@@ -551,7 +551,6 @@ class ChartState {
 
     clearLayout() {
         window.flutterChart?.indicators.clearIndicators();
-        window.flutterChart?.drawingTool.clearDrawingTool();
     }
 
     async saveDrawings() {

--- a/src/store/DrawToolsStore.ts
+++ b/src/store/DrawToolsStore.ts
@@ -208,6 +208,7 @@ export default class DrawToolsStore {
     // Callback that runs when the chart is loaded
     onLoad(drawings: TDrawingCreatedConfig[]) {
         this.activeToolsGroup = [];
+        this.hideDrawingConfirmation();
 
         drawings.forEach((item: TDrawingCreatedConfig) => {
             if (typeof item === 'string') {


### PR DESCRIPTION
## Problems

### 1. Drawing tools disappear after visiting contract details

When a user added drawing tools to the trade chart, navigated to the contract details page, then came back to the trade chart, the added drawing tools were gone.

**Root cause:** When there was no saved layout to restore, `ChartState.clearLayout()` was called. This called `drawingTool.clearDrawingTool()` on the Flutter side, which wiped the user's drawings from `SharedPreferences` for the current symbol. Since drawings are persisted per-symbol in `SharedPreferences`, this permanently deleted them.

### 2. Drawing tools appeared on the chart with a ~6 second delay

After switching symbols or refreshing, saved drawing tools were loaded and displayed with a noticeable delay of around 6 seconds.

**Root cause:** The drawing tools were loaded using two back-to-back hardcoded timers:
- `Future.delayed(5 seconds)` — waiting for the chart to be ready
- `Future.delayed(1 second)` — waiting before notifying the JS side

These were a workaround (marked with `TODO`) for a missing "chart is ready" signal. Drawing tools cannot be applied before the chart's price axis exists, so the code was sleeping for an arbitrary duration to approximate readiness instead of waiting for the actual condition.

---

## Solution

### Fix 1: Isolate drawing tools from the contract-details chart (replay chart)

- **`deriv_chart_wrapper.dart`**: A dedicated empty `drawingToolsRepo` (`emptyDrawingToolsRepo`) is now passed to the chart when it is in replay mode (`startWithDataFitMode = true`). This repo has no items and is never loaded from `SharedPreferences`, so the replay chart has nothing to render. A `ValueKey` tied to `startWithDataFitMode` forces a full Flutter widget remount when switching between trade and replay modes, ensuring the `InteractiveLayer` starts fresh with the empty repo and no stale state carries over.

- **`ChartState.ts`**: Removed the `drawingTool.clearDrawingTool()` call from `clearLayout()`. Layout restoration has no business touching the user's drawings — the replay isolation is now handled entirely on the Flutter side.

- **`drawing_tool.dart`**: Added `emptyDrawingToolsRepo`, an always-empty `AddOnsRepository` with a sentinel `sharedPrefKey` that is never written to or read from real storage.

### Fix 2: Replace timers with a proper chart-ready signal

- **`chart_app.dart`**: Added a `Completer<void> _chartReadyCompleter` that completes inside the existing `_processChartVisibilityChange(true)` callback — the exact moment the feed has loaded and the first frame has painted. `newChart` is now `async` and awaits `chartReady` before loading drawings. The completer is re-armed on every symbol switch so the gate works correctly across navigations. Drawing load is skipped entirely when `startWithDataFitMode = true` (replay chart), leaving the live repo untouched.

- **`drawing_tool.dart`**: Removed both `Future.delayed` timers and the surrounding `addPostFrameCallback` wrappers. Drawing load logic moved to a new `loadAndNotifyDrawings()` method called by `ChartApp.newChart` only after the chart is confirmed ready.

- **`dart_interop.dart`**: Wrapped the now-async `_app.newChart(payload)` with `unawaited()` so the JS bridge surface stays fire-and-forget.
