### PR TITLE
Akmal / fix: seed initial theme before first paint to prevent light flash in dark mode

### DIFF
--- a/chart_app/lib/src/models/chart_config.dart
+++ b/chart_app/lib/src/models/chart_config.dart
@@ -5,11 +5,22 @@ import 'package:chart_app/src/helpers/color.dart';
 import 'package:deriv_chart/core_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:chart_app/src/interop/js_interop.dart';
+import 'package:web/web.dart' as web;
 
 /// State and methods of chart web adapter config.
 class ChartConfigModel extends ChangeNotifier {
   /// Initialize
-  ChartConfigModel();
+  ChartConfigModel() {
+    // The JS wrapper exposes the host's current theme on
+    // `window.flutterChartTheme` before the engine boots. Seeding it here
+    // makes the engine's very first frame match the host theme instead of
+    // flashing the light default until updateTheme arrives via interop.
+    final Object? initialTheme =
+        web.window.getProperty('flutterChartTheme'.toJS)?.dartify();
+    if (initialTheme == 'dark') {
+      theme = ChartDefaultDarkTheme();
+    }
+  }
 
   /// Style of the chart
   ChartStyle style = ChartStyle.line;

--- a/src/components/SmartChart.tsx
+++ b/src/components/SmartChart.tsx
@@ -9,7 +9,7 @@ const SmartChart = React.forwardRef<
 >(({ children, ...props }, ref) => {
     const is_context_intialized = React.useRef(false);
     if (!is_context_intialized.current) {
-        initContext();
+        initContext(props.settings);
         is_context_intialized.current = true;
     }
 

--- a/src/store/ChartSettingStore.ts
+++ b/src/store/ChartSettingStore.ts
@@ -35,6 +35,7 @@ export default class ChartSettingStore {
             minimumLeftBars: observable,
             updateActiveLanguage: action.bound,
             setLanguage: action.bound,
+            setInitialTheme: action.bound,
             setTheme: action.bound,
             setPosition: action.bound,
             showCountdown: action.bound,
@@ -211,11 +212,30 @@ export default class ChartSettingStore {
         }
         this.saveSetting();
     }
+    /**
+     * Seeds the theme at store construction, before the first render commits,
+     * so the chart never paints its default light theme for a frame when the
+     * host mounts it in dark mode. Unlike setTheme, this must not trigger the
+     * settings-save/GA side effects — the value comes from the host, not the user.
+     */
+    setInitialTheme(theme?: string) {
+        if (theme && this.theme !== theme) {
+            this.theme = theme;
+            // A reused engine (window.flutterChartElement survives remounts) keeps
+            // the theme from its previous mount; sync it here because setTheme()
+            // will see an unchanged value later and early-return.
+            this.mainStore.chartAdapter.updateTheme(theme);
+        }
+        // A cold engine reads this global at bootstrap so its very first frame
+        // is painted with the correct theme instead of the Dart light default.
+        window.flutterChartTheme = this.theme;
+    }
     setTheme(theme: string) {
         if (this.theme === theme) {
             return;
         }
         this.theme = theme;
+        window.flutterChartTheme = theme;
 
         this.mainStore.drawTools.updateTheme();
 

--- a/src/store/ChartSettingStore.ts
+++ b/src/store/ChartSettingStore.ts
@@ -219,16 +219,23 @@ export default class ChartSettingStore {
      * settings-save/GA side effects — the value comes from the host, not the user.
      */
     setInitialTheme(theme?: string) {
-        if (theme && this.theme !== theme) {
-            this.theme = theme;
-            // A reused engine (window.flutterChartElement survives remounts) keeps
-            // the theme from its previous mount; sync it here because setTheme()
-            // will see an unchanged value later and early-return.
-            this.mainStore.chartAdapter.updateTheme(theme);
-        }
+        // On a warm remount (e.g. mobile Trade -> Menu -> Trade) the JS store is
+        // rebuilt with the default 'light' theme, but the Flutter engine and the
+        // window.flutterChartTheme global survive. Resolve the real target from
+        // the host prop first, then the last-known global, then the store default,
+        // so we never regress a dark chart to light just because the fresh store
+        // hasn't been told the current theme yet.
+        const resolvedTheme = theme || window.flutterChartTheme || this.theme;
+        this.theme = resolvedTheme;
         // A cold engine reads this global at bootstrap so its very first frame
         // is painted with the correct theme instead of the Dart light default.
-        window.flutterChartTheme = this.theme;
+        window.flutterChartTheme = resolvedTheme;
+        // Always push to the (possibly warm) engine, without an equality guard:
+        // it retains the theme from its previous mount, and setTheme() will later
+        // early-return on an unchanged value. initContext runs during render,
+        // before onMount reattaches the canvas, so the engine repaints the correct
+        // theme before it becomes visible again — preventing the wrong-theme flash.
+        this.mainStore.chartAdapter.updateTheme(resolvedTheme);
     }
     setTheme(theme: string) {
         if (this.theme === theme) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,7 +24,7 @@ import HighestLowestStore from './HighestLowestStore';
 import PaginationLoaderStore from './PaginationLoaderStore';
 import ToolbarWidgetStore from './ToolbarWidgetStore';
 import ScrollStore from './ScrollStore';
-import { TMainStore } from '../types';
+import { TMainStore, TSettings } from '../types';
 import ChartAdapterStore from './ChartAdapterStore';
 
 export default class MainStore implements TMainStore {
@@ -57,8 +57,11 @@ export default class MainStore implements TMainStore {
 
 let stores_context: React.Context<TMainStore>;
 
-export const initContext = (): void => {
+export const initContext = (initialSettings?: TSettings): void => {
     const root_store = new MainStore();
+    // Seed the theme before the context (and thus the first render) exists, so the
+    // initial paint already carries the host's theme instead of the light default.
+    root_store.chartSetting.setInitialTheme(initialSettings?.theme);
     stores_context = React.createContext<TMainStore>(root_store);
 };
 

--- a/src/types/props.types.ts
+++ b/src/types/props.types.ts
@@ -20,6 +20,8 @@ declare global {
     interface Window {
         flutterChart: TFlutterChart;
         flutterChartElement: HTMLElement;
+        /** Current chart theme ('light' | 'dark'), read by the Flutter engine at bootstrap so its first frame matches the host theme */
+        flutterChartTheme?: string;
         _flutter: {
             loader: {
                 /** New Flutter 3.x API — handles WASM + JS build selection */


### PR DESCRIPTION
On page refresh in a dark-theme host, the chart flashed light for a split second, in two stages:

1. ChartSettingStore.theme hard-defaults to 'light' and the chart root's `smartcharts-${theme}` class is computed from it, while the host's settings prop was only applied in a post-commit useEffect — so the first painted frame was always `.smartcharts-light` (white) inside a dark page.

2. The Flutter engine constructed ChartConfigModel with ChartDefaultLightTheme, and the JS->engine theme handoff is parked on `await when(() => isChartLoaded)` — so every frame the engine painted during boot (including the pre-feed white Container) was light.

Fix:
- SmartChart passes props.settings into initContext, and the new setInitialTheme action seeds ChartSettingStore.theme at store construction — before the React context (and thus the first render) exists — so the first committed frame already carries the host theme.
- The current theme is mirrored to `window.flutterChartTheme` (setInitialTheme + setTheme), and ChartConfigModel reads it in its constructor, so a cold engine boots with the correct theme instead of defaulting to light until updateTheme arrives via interop.
- For a reused engine (window.flutterChartElement survives remounts), setInitialTheme pushes the theme through chartAdapter.updateTheme since setTheme will early-return on the now-unchanged value.

Light-theme hosts are unaffected: seeding with 'light' matches the default, which is exactly the early-return path they already take today.