### PR TITLE
fix: indicators config id

### DIFF
--- a/chart_app/lib/src/models/indicators.dart
+++ b/chart_app/lib/src/models/indicators.dart
@@ -28,15 +28,35 @@ class IndicatorsModel {
 
   /// To add or update an indicator
   void addOrUpdateIndicator(String dataString, int? index) {
-    final Map<String, dynamic> config = json.decode(dataString)..remove('id');
+    final Map<String, dynamic> config = json.decode(dataString);
+
+    // `id` is the JS side's stable identifier for this indicator instance -
+    // assigned once via getUniqueId() when it's first added, and preserved
+    // across page reloads since it's part of what JS's own saveLayout /
+    // restoreStudies round-trips. Used directly as configId - the stable
+    // identity flutter-chart's resizable indicator panels key their
+    // persisted size by - instead of being discarded. Without it, every
+    // indicator fell back to a `title#number` key that isn't guaranteed
+    // unique (`number` is never sent either, so it defaults to 0) and can't
+    // survive a reload (title/number can be recomputed differently on
+    // restore), which could both collide two panels onto the same key -
+    // corrupting the web layout's panel-size bookkeeping and pushing
+    // content past the viewport - and silently drop a resized panel's saved
+    // size after a reload.
+    final String? configId = config.remove('id') as String?;
 
     final IndicatorConfig? indicatorConfig = IndicatorConfig.fromJson(config);
 
-    if (indicatorConfig != null) {
-      index != null && index > -1
-          ? indicatorsRepo.updateAt(index, indicatorConfig)
-          : indicatorsRepo.add(indicatorConfig);
+    if (indicatorConfig == null) {
+      return;
     }
+
+    final IndicatorConfig configWithId =
+        indicatorConfig.copyWith(configId: configId);
+
+    index != null && index > -1
+        ? indicatorsRepo.updateAt(index, configWithId)
+        : indicatorsRepo.add(configWithId);
   }
 
   /// To remove an existing indicator


### PR DESCRIPTION
# fix: use the JS indicator `id` as `configId`

## Problem

Adding more than one indicator left the indicator panels cut off — content pushed past the bottom of the viewport.

`flutter-chart`'s resizable indicator panels key each panel's height fraction by `IndicatorConfig.configId`. But `addOrUpdateIndicator` was dropping the `id` field from the incoming JS payload, so every indicator fell back to the default `configId` of `title#number` — and `number` is never sent from the JS side, so it defaults to `0`.

That makes the key non-unique: two indicators of the same type both resolve to `rsi#0`. Two panels then share a single fraction entry, so the panel-size bookkeeping no longer accounts for every panel, the fractions don't cover the available height, and content overflows — the visible "cut off" symptom.

## Solution

Use the JS side's own identifier as `configId` instead of discarding it.

In `chart_app/lib/src/models/indicators.dart`, `addOrUpdateIndicator` now pulls `id` off the decoded payload and applies it to the parsed config:

```dart
final String? configId = config.remove('id') as String?;

final IndicatorConfig? indicatorConfig = IndicatorConfig.fromJson(config);
if (indicatorConfig == null) {
  return;
}

final IndicatorConfig configWithId =
    indicatorConfig.copyWith(configId: configId);
```

The JS `id` is the right identity to use: it's assigned once via `getUniqueId()` when an indicator is first added, so it is genuinely unique per indicator instance.

`remove` is used rather than a plain read so the key doesn't leak into `IndicatorConfig.fromJson`.

## Result

Each indicator panel gets its own distinct size entry, so multiple indicators lay out within the available height instead of overflowing and being cut off.